### PR TITLE
Fixing bug where scaletype cannot be changed from styles.

### DIFF
--- a/library/src/main/res/layout/base_thumbnail_layout.xml
+++ b/library/src/main/res/layout/base_thumbnail_layout.xml
@@ -20,7 +20,6 @@
 <ImageView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/card_thumbnail_image"
-    android:scaleType="centerCrop"
     style="@style/card_thumbnail_image"/>
 
 


### PR DESCRIPTION
Inline attributes override styles. Therefore this is always "centerCrop"
unless the line is removed.

I think this is a pretty straightforward bug fix. Let me know if I'm missing something. Thanks for all the help.
