### PR TITLE
Thumbnail card with custom source

### DIFF
--- a/demo/stock/src/main/java/it/gmariotti/cardslib/demo/cards/GplayCardCustomSource.java
+++ b/demo/stock/src/main/java/it/gmariotti/cardslib/demo/cards/GplayCardCustomSource.java
@@ -1,0 +1,125 @@
+/*
+ * ******************************************************************************
+ *   Copyright (c) 2013 Gabriele Mariotti.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *  *****************************************************************************
+ */
+
+package it.gmariotti.cardslib.demo.cards;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.util.DisplayMetrics;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.RatingBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import it.gmariotti.cardslib.demo.R;
+import it.gmariotti.cardslib.library.internal.Card;
+import it.gmariotti.cardslib.library.internal.CardHeader;
+import it.gmariotti.cardslib.library.internal.CardThumbnail;
+import it.gmariotti.cardslib.library.internal.base.BaseCard;
+
+/**
+ * This class provides a simple example as Google Play card.
+ * The Google maps icon this time is loaded from package manager.
+ *
+ * @author Gabriele Mariotti (gabri.mariotti@gmail.com), Ronald Ammann (ramdroid.fn@gmail.com)
+ */
+public class GplayCardCustomSource extends Card {
+
+    public GplayCardCustomSource(Context context) {
+        super(context, R.layout.carddemo_gplay_inner_content);
+        init();
+    }
+
+    public GplayCardCustomSource(Context context, int innerLayout) {
+        super(context, innerLayout);
+        init();
+    }
+
+    private void init() {
+        CardHeader header = new CardHeader(getContext());
+        header.setButtonOverflowVisible(true);
+        header.setTitle("Google Maps");
+        header.setPopupMenu(R.menu.popupmain, new CardHeader.OnClickCardHeaderPopupMenuListener() {
+            @Override
+            public void onMenuItemClick(BaseCard card, MenuItem item) {
+                Toast.makeText(getContext(), item.getTitle(), Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        addCardHeader(header);
+
+        CardThumbnail thumbnail = new CardThumbnail(getContext());
+        thumbnail.setCustomSource(new CardThumbnail.CustomSource() {
+            @Override
+            public String getTag() {
+                return "com.google.android.apps.maps";
+            }
+
+            @Override
+            public Bitmap getBitmap() {
+                PackageManager pm = mContext.getPackageManager();
+                Bitmap bitmap = null;
+                try {
+		    bitmap = drawableToBitmap(pm.getApplicationIcon(getTag()));
+		}
+		catch (PackageManager.NameNotFoundException e) {
+		}
+		return bitmap;
+	    }
+
+            private Bitmap drawableToBitmap (Drawable drawable) {
+                if (drawable instanceof BitmapDrawable) {
+                    return ((BitmapDrawable)drawable).getBitmap();
+                }
+
+                Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+                Canvas canvas = new Canvas(bitmap);
+                drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+                drawable.draw(canvas);
+
+                return bitmap;
+            }
+        });
+        addCardThumbnail(thumbnail);
+    }
+
+    @Override
+    public void setupInnerViewElements(ViewGroup parent, View view) {
+
+        TextView title = (TextView) view.findViewById(R.id.carddemo_gplay_main_inner_title);
+        title.setText("FREE");
+
+        TextView subtitle = (TextView) view.findViewById(R.id.carddemo_gplay_main_inner_subtitle);
+        subtitle.setText("Very popular with...");
+
+        RatingBar mRatingBar = (RatingBar) parent.findViewById(R.id.carddemo_gplay_main_inner_ratingBar);
+
+        mRatingBar.setNumStars(5);
+        mRatingBar.setMax(5);
+        mRatingBar.setStepSize(0.5f);
+        mRatingBar.setRating(4.7f);
+    }
+
+
+}

--- a/demo/stock/src/main/java/it/gmariotti/cardslib/demo/fragment/ThumbnailFragment.java
+++ b/demo/stock/src/main/java/it/gmariotti/cardslib/demo/fragment/ThumbnailFragment.java
@@ -26,6 +26,7 @@ import android.widget.ScrollView;
 
 import it.gmariotti.cardslib.demo.R;
 import it.gmariotti.cardslib.demo.cards.CustomThumbCard;
+import it.gmariotti.cardslib.demo.cards.GplayCardCustomSource;
 import it.gmariotti.cardslib.library.internal.Card;
 import it.gmariotti.cardslib.library.internal.CardHeader;
 import it.gmariotti.cardslib.library.internal.CardThumbnail;
@@ -64,6 +65,7 @@ public class ThumbnailFragment extends BaseFragment {
         init_card_thumb_resourceId();
         init_card_thumb_resourceURL();
         init_card_thumb_resourceURL_style();
+        init_card_thumb_custom_source();
     }
 
     /**
@@ -163,5 +165,16 @@ public class ThumbnailFragment extends BaseFragment {
         cardView.setCard(card);
     }
 
+    /**
+     * This method builds a card with a custom source thumbnail
+     */
+    private void init_card_thumb_custom_source() {
 
+        //Create a Card
+        Card card = new GplayCardCustomSource(getActivity());
+
+        //Set card in the cardView
+        CardView cardView = (CardView) getActivity().findViewById(R.id.carddemo_thumb_customsource);
+        cardView.setCard(card);
+    }
 }

--- a/demo/stock/src/main/res/layout/demo_fragment_thumbnail.xml
+++ b/demo/stock/src/main/res/layout/demo_fragment_thumbnail.xml
@@ -67,7 +67,7 @@
                 card:card_layout_resourceID="@layout/card_thumbnail_layout"
                 android:layout_marginTop="12dp"/>
 
-            <!-- Customize you thumbnail -->
+	    <!-- Customize you thumbnail -->
             <TextView
                 style="@style/AppTheme.TitleText"
                 android:layout_width="wrap_content"
@@ -83,6 +83,22 @@
                 card:card_layout_resourceID="@layout/card_thumbnail_layout"
                 android:layout_marginTop="12dp"/>
 
+            <!-- Custom Source Thumbnail-->
+            <TextView
+                style="@style/AppTheme.TitleText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/demo_section_thumb_customsource"/>
+
+            <it.gmariotti.cardslib.library.view.CardView
+                android:id="@+id/carddemo_thumb_customsource"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="12dp"
+                android:layout_marginRight="12dp"
+                card:card_layout_resourceID="@layout/card_thumbnail_layout"
+                android:layout_marginTop="12dp"/>
+	    
             <!-- Empty view-->
             <View
                 android:layout_width="match_parent"

--- a/demo/stock/src/main/res/values/strings.xml
+++ b/demo/stock/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="demo_section_thumb_id">Thumbnail from resource ID</string>
     <string name="demo_section_thumb_url">Thumbnail from resource URL</string>
     <string name="demo_section_thumb_style">Styling your Thumbnail card</string>
+    <string name="demo_section_thumb_customsource">Thumbnail from custom source</string>
 
     <string name="demo_section_card_title">Card with simple title</string>
     <string name="demo_section_card_inner">Card with custom inner layout</string>

--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardThumbnail.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardThumbnail.java
@@ -20,7 +20,6 @@ package it.gmariotti.cardslib.library.internal;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 

--- a/library/src/main/java/it/gmariotti/cardslib/library/view/component/CardThumbnailView.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/view/component/CardThumbnailView.java
@@ -42,10 +42,11 @@ import java.lang.ref.WeakReference;
 import java.net.URL;
 
 import it.gmariotti.cardslib.library.Constants;
-import it.gmariotti.cardslib.library.R;
 import it.gmariotti.cardslib.library.internal.CardThumbnail;
 import it.gmariotti.cardslib.library.utils.CacheUtil;
 import it.gmariotti.cardslib.library.view.base.CardViewInterface;
+
+import it.gmariotti.cardslib.library.R;
 
 /**
  * Compound View for Thumbnail Component.


### PR DESCRIPTION
I added support for a custom source for CardThumbnail. Instead of a resource ID or URL you can now choose anything else. When creating the CardThumbnail you have to implement the CustomSource interface, and here you fetch your bitmap from whatever source. In my demo I'm using Package Manager.
