### PR TITLE
Allow header popup menu to be customized dynamically

### DIFF
--- a/doc/HEADER.md
+++ b/doc/HEADER.md
@@ -72,11 +72,17 @@ If you want a `CardHeader` with the overflow button you can use this simple code
             public void onMenuItemClick(BaseCard card, MenuItem item) {
                 Toast.makeText(getActivity(), "Click on "+item.getTitle(), Toast.LENGTH_SHORT).show();
             }
+        },
+        new CardHeader.OnPrepareCardHeaderPopupMenuListener() {
+            @Override
+            public void onPreparePopupMenu(BaseCard card, PopupMenu menu) {
+                menu.getMenu().add("Dynamic Item");
+            }
         });
         card.addCardHeader(header);
 ```
 
-You can use the listener  `CardHeader.OnClickCardHeaderPopupMenuListener` to listen callback when an item menu is clicked.
+You can use the listener  `CardHeader.OnClickCardHeaderPopupMenuListener` to listen callback when an item menu is clicked. The third parameter `CardHeader.OnPrepareCardHeaderPopupMenuListener` is optional and can be used to create dynamic menu items.
 
 As described [below](#style), the overflow icon is defined with this style:
 

--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardHeader.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardHeader.java
@@ -23,6 +23,7 @@ import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import it.gmariotti.cardslib.library.R;
@@ -117,6 +118,10 @@ public class CardHeader extends BaseCard {
      */
     protected OnClickCardHeaderPopupMenuListener mPopupMenuListener;
 
+    /**
+     * Listener invoked when the PopupMenu being prepared
+     */
+    protected OnPrepareCardHeaderPopupMenuListener mPopupMenuPrepareListener;
 
     /**
      * Listener invoked when Other Button is clicked
@@ -199,6 +204,13 @@ public class CardHeader extends BaseCard {
     }
 
     /**
+     * Interface to handle the callback when a popup menu being prepared
+     */
+    public interface OnPrepareCardHeaderPopupMenuListener {
+        public void onPreparePopupMenu(BaseCard card, PopupMenu menu);
+    }
+
+    /**
      * Interface to handle callbacks when ExpandButton is clicked
      * Currently is never used
      */
@@ -226,9 +238,10 @@ public class CardHeader extends BaseCard {
      * @param menuRes  The menu resource ID to use for the card's popup menu.
      * @param listener A listener invoked when an option in the popup menu is tapped by the user.
      */
-    public void setPopupMenu(int menuRes, OnClickCardHeaderPopupMenuListener listener) {
+    public void setPopupMenu(int menuRes, OnClickCardHeaderPopupMenuListener listener, OnPrepareCardHeaderPopupMenuListener prepareListener) {
         mPopupMenu = menuRes;
         mPopupMenuListener = listener;
+        mPopupMenuPrepareListener = prepareListener;
 
         if (menuRes==NO_POPUP_MENU){
             mIsButtonOverflowVisible=false;
@@ -236,6 +249,10 @@ public class CardHeader extends BaseCard {
         }else{
             mIsButtonOverflowVisible=true;
         }
+    }
+
+    public void setPopupMenu(int menuRes, OnClickCardHeaderPopupMenuListener listener) {
+        setPopupMenu(menuRes, listener, null);
     }
 
     // -------------------------------------------------------------
@@ -359,12 +376,30 @@ public class CardHeader extends BaseCard {
     }
 
     /**
+     * Return the popup prepare listener invoked when the PopupMenu is being prepared
+     *
+     * @return  popup listener
+     */
+    public OnPrepareCardHeaderPopupMenuListener getPopupMenuPrepareListener() {
+        return mPopupMenuPrepareListener;
+    }
+
+    /**
      * Sets the popup listener invoked when a item in PopupMenu is clicked
      *
      * @param popupMenuListener  popup listener
      */
     public void setPopupMenuListener(OnClickCardHeaderPopupMenuListener popupMenuListener) {
         mPopupMenuListener = popupMenuListener;
+    }
+
+    /**
+     * Sets the popup listener invoked when the PopupMenu is being prepared
+     *
+     * @param popupMenuListener  popup prepare listener
+     */
+    public void setPopupMenuPrepareListener(OnPrepareCardHeaderPopupMenuListener popupMenuListener) {
+        mPopupMenuPrepareListener = popupMenuListener;
     }
 
     /**

--- a/library/src/main/java/it/gmariotti/cardslib/library/view/component/CardHeaderView.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/view/component/CardHeaderView.java
@@ -402,6 +402,10 @@ public class CardHeaderView extends FrameLayout implements CardViewInterface {
                             return false;
                         }
                     });
+                    // allow dynamic customization on popup menu
+                    if (mCardHeader.getPopupMenuPrepareListener() != null) {
+                        mCardHeader.getPopupMenuPrepareListener().onPreparePopupMenu(mCardHeader.getParentCard(), popup);
+                    }
                     popup.show();
                 }
             });


### PR DESCRIPTION
Sometime the header popup menu are dynamic according to the content of
the card. This commit allows the menu to be customized after being
inflated. The menu object is passed to the listener, which can be
specified after creating the header object.
