### PR TITLE
Fix CardListView crash when header views are present

### DIFF
--- a/library/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissListViewTouchListener.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissListViewTouchListener.java
@@ -252,6 +252,7 @@ public class SwipeDismissListViewTouchListener implements View.OnTouchListener {
                 }
                 if (dismiss && mDownPosition != ListView.INVALID_POSITION) {
                     // dismiss
+                    // we have to abstract away the header indexes here because evidently the adapter can't deal with life. (asarazan)
                     dismiss(mDownView, mDownPosition - mListView.getHeaderViewsCount(), dismissRight);
 
                 } else {


### PR DESCRIPTION
Just offset the dismiss position by header view count.
