### PR TITLE
CursorAdapter: dont register ContentObserver in basic constructor

### DIFF
--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardCursorAdapter.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardCursorAdapter.java
@@ -71,20 +71,17 @@ public abstract class CardCursorAdapter extends BaseCardCursorAdapter  {
     // -------------------------------------------------------------
 
     public CardCursorAdapter(Context context) {
-        super(context, null, false);
-        mContext= context;
+        super(context, null, 0);
         mExpandedIds = new ArrayList<String>();
     }
 
     protected CardCursorAdapter(Context context, Cursor c, boolean autoRequery) {
         super(context, c, autoRequery);
-        mContext= context;
         mExpandedIds = new ArrayList<String>();
     }
 
     protected CardCursorAdapter(Context context, Cursor c, int flags) {
         super(context, c, flags);
-        mContext= context;
         mExpandedIds = new ArrayList<String>();
     }
 

--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardGridCursorAdapter.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardGridCursorAdapter.java
@@ -63,18 +63,15 @@ public abstract class CardGridCursorAdapter extends BaseCardCursorAdapter  {
     // -------------------------------------------------------------
 
     public CardGridCursorAdapter(Context context) {
-        super(context, null, false);
-        mContext= context;
+        super(context, null, 0);
     }
 
     protected CardGridCursorAdapter(Context context, Cursor c, boolean autoRequery) {
         super(context, c, autoRequery);
-        mContext= context;
     }
 
     protected CardGridCursorAdapter(Context context, Cursor c, int flags) {
         super(context, c, flags);
-        mContext= context;
     }
 
     // -------------------------------------------------------------


### PR DESCRIPTION
when using LoaderCallbacks we dont want to set
FLAG_REGISTER_CONTENT_OBSERVER in the adapter as that
will cause us to leak our context on configuration changes

also super sets context so no need to do it again

Change-Id: I08da5d2672df69da968bba28c206e57e1aecb389
