### PR TITLE
Added Expandable+Swipable items to the card list

### DIFF
--- a/demo/stock/src/main/java/it/gmariotti/cardslib/demo/cards/GoogleNowWeatherCard.java
+++ b/demo/stock/src/main/java/it/gmariotti/cardslib/demo/cards/GoogleNowWeatherCard.java
@@ -22,7 +22,11 @@ import android.content.Context;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
+import android.view.animation.Transformation;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -132,8 +136,31 @@ public class GoogleNowWeatherCard extends CardWithList {
         city.setText(weatherObject.city);
         temperature.setText(weatherObject.temperature + weatherObject.temperatureUnit);
 
+        TextView subTv1 = (TextView) convertView.findViewById(R.id.exTV1);
+        TextView subTv2 = (TextView) convertView.findViewById(R.id.exTV2);
+        TextView subTv3 = (TextView) convertView.findViewById(R.id.exTV3);
+
+        subTv1.setOnClickListener(subItemClick);
+        subTv2.setOnClickListener(subItemClick);
+        subTv3.setOnClickListener(subItemClick);
+
+        RelativeLayout expandedLayout = ((RelativeLayout)convertView.findViewById(R.id.demo_card_expandable_list_item));
+        if(object.isExpanded()){
+            expandedLayout.setVisibility(View.VISIBLE);
+        }else{
+            expandedLayout.setVisibility(View.GONE);
+        }
+
+
         return  convertView;
     }
+
+    View.OnClickListener subItemClick = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            Toast.makeText(getContext(),"Pressed sub item "+((TextView)view).getText(),Toast.LENGTH_SHORT).show();
+        }
+    };
 
     @Override
     public int getChildLayoutId() {
@@ -162,8 +189,72 @@ public class GoogleNowWeatherCard extends CardWithList {
                 @Override
                 public void onItemClick(LinearListView parent, View view, int position, ListObject object) {
                     Toast.makeText(getContext(), "Click on " + getObjectId(), Toast.LENGTH_SHORT).show();
+                    RelativeLayout expandedLayout = ((RelativeLayout)view.findViewById(R.id.demo_card_expandable_list_item));
+                    if(object.isExpanded())  {
+                        collapse(expandedLayout);
+                        expandedLayout.setVisibility(View.GONE);
+                        object.setExpanded(false);
+                    }else{
+                        expand(expandedLayout);
+                        expandedLayout.setVisibility(View.VISIBLE);
+                        object.setExpanded(true);
+                    }
+
                 }
             });
+        }
+
+        public void expand(final View v) {
+            v.measure(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+            final int targtetHeight = v.getMeasuredHeight();
+
+            v.getLayoutParams().height = 0;
+            v.setVisibility(View.VISIBLE);
+            Animation a = new Animation()
+            {
+                @Override
+                protected void applyTransformation(float interpolatedTime, Transformation t) {
+                    v.getLayoutParams().height = interpolatedTime == 1
+                            ? LinearLayout.LayoutParams.WRAP_CONTENT
+                            : (int)(targtetHeight * interpolatedTime);
+                    v.requestLayout();
+                }
+
+                @Override
+                public boolean willChangeBounds() {
+                    return true;
+                }
+            };
+
+            // 1dp/ms
+            a.setDuration((int)(targtetHeight / v.getContext().getResources().getDisplayMetrics().density));
+            v.startAnimation(a);
+        }
+
+        public void collapse(final View v) {
+            final int initialHeight = v.getMeasuredHeight();
+
+            Animation a = new Animation()
+            {
+                @Override
+                protected void applyTransformation(float interpolatedTime, Transformation t) {
+                    if(interpolatedTime == 1){
+                        v.setVisibility(View.GONE);
+                    }else{
+                        v.getLayoutParams().height = initialHeight - (int)(initialHeight * interpolatedTime);
+                        v.requestLayout();
+                    }
+                }
+
+                @Override
+                public boolean willChangeBounds() {
+                    return true;
+                }
+            };
+
+            // 1dp/ms
+            a.setDuration((int)(initialHeight / v.getContext().getResources().getDisplayMetrics().density));
+            v.startAnimation(a);
         }
 
     }

--- a/demo/stock/src/main/java/it/gmariotti/cardslib/demo/cards/GoogleNowWeatherCard.java
+++ b/demo/stock/src/main/java/it/gmariotti/cardslib/demo/cards/GoogleNowWeatherCard.java
@@ -19,6 +19,7 @@
 package it.gmariotti.cardslib.demo.cards;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -162,6 +163,8 @@ public class GoogleNowWeatherCard extends CardWithList {
         }
     };
 
+
+
     @Override
     public int getChildLayoutId() {
         return R.layout.carddemo_googlenowweather_inner_main;
@@ -194,10 +197,18 @@ public class GoogleNowWeatherCard extends CardWithList {
                         collapse(expandedLayout);
                         expandedLayout.setVisibility(View.GONE);
                         object.setExpanded(false);
+                        getLinearListAdapter().setLastExpanded(null);
                     }else{
+                        //getLinearListAdapter().collapseAll();  only use this if there is a scenario where multiple items will be expanded at once
+
+                        getLinearListAdapter().collapseLastExpanded(); //this is much more efficient
+
+                        object.setExpanded(true);
+                        getLinearListAdapter().setLastExpanded(object);
+                        getLinearListAdapter().notifyDataSetChanged();
                         expand(expandedLayout);
                         expandedLayout.setVisibility(View.VISIBLE);
-                        object.setExpanded(true);
+
                     }
 
                 }

--- a/demo/stock/src/main/res/layout/carddemo_googlenowweather_inner_main.xml
+++ b/demo/stock/src/main/res/layout/carddemo_googlenowweather_inner_main.xml
@@ -19,13 +19,15 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:orientation="vertical"
-              android:layout_marginLeft="8dp"
-              android:layout_marginRight="8dp"
-              android:background="@drawable/demo_item_selector"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+
+    android:tag="Parent">
 
     <View
         android:layout_width="match_parent"
@@ -35,9 +37,12 @@
         android:background="@color/demo_card_line_weather_color"/>
 
     <RelativeLayout
+
+        android:background="@drawable/demo_item_selector"
+        android:id="@+id/demo_card_list_item_layout"
         android:layout_width="match_parent"
-        android:layout_marginLeft="12dp"
-        android:layout_marginRight="12dp"
+        android:paddingLeft="12dp"
+        android:paddingRight="12dp"
         android:layout_gravity="center_vertical"
         android:layout_height="wrap_content"
         android:minHeight="48dp">
@@ -75,5 +80,40 @@
 
 
     </RelativeLayout>
+
+
+    <RelativeLayout
+        android:id="@+id/demo_card_expandable_list_item"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+
+        android:visibility="gone">
+
+        <TextView
+            android:background="@drawable/demo_item_selector"
+            android:id="@+id/exTV1"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Test line 1"
+            android:padding="10dp"/>
+        <TextView
+            android:background="@drawable/demo_item_selector"
+            android:id="@+id/exTV2"
+            android:layout_below="@id/exTV1"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Test line 2"
+            android:padding="10dp"/>
+        <TextView
+            android:background="@drawable/demo_item_selector"
+            android:id="@+id/exTV3"
+            android:layout_below="@id/exTV2"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="Test line 3"
+            android:padding="10dp"/>
+
+    </RelativeLayout>
+
 
 </LinearLayout>

--- a/library/src/main/java/it/gmariotti/cardslib/library/prototypes/CardWithList.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/prototypes/CardWithList.java
@@ -33,6 +33,7 @@ import java.util.List;
 import it.gmariotti.cardslib.library.R;
 import it.gmariotti.cardslib.library.internal.Card;
 import it.gmariotti.cardslib.library.internal.CardHeader;
+import it.gmariotti.cardslib.library.view.listener.SwipeDismissListItemViewTouchListener;
 
 /**
  * @author Gabriele Mariotti (gabri.mariotti@gmail.com)
@@ -363,6 +364,13 @@ public abstract class CardWithList extends Card {
          */
         public OnItemClickListener getOnItemClickListener();
 
+        /**
+         * @return Is the list item expanded or not
+         */
+        public Boolean isExpanded();
+
+        public void setExpanded(Boolean expanded);
+
     }
 
 
@@ -403,6 +411,7 @@ public abstract class CardWithList extends Card {
      */
     public class DefaultListObject implements ListObject {
 
+        private Boolean isItemExpanded = false;
         protected String mObjectId;
         protected OnItemClickListener mOnItemClickListener;
 
@@ -424,6 +433,17 @@ public abstract class CardWithList extends Card {
         public OnItemClickListener getOnItemClickListener() {
             return mOnItemClickListener;
         }
+
+        @Override
+        public Boolean isExpanded(){
+            return isItemExpanded;
+        }
+
+        @Override
+        public void setExpanded(Boolean expanded){
+            this.isItemExpanded = expanded;
+        }
+
     }
 
     // -------------------------------------------------------------
@@ -487,7 +507,7 @@ public abstract class CardWithList extends Card {
     /**
      * ListAdapter used to populate the LinearLayout inside the Card.
      */
-    protected class LinearListAdapter extends ArrayAdapter<ListObject> {
+    public class LinearListAdapter extends ArrayAdapter<ListObject> {
 
         LayoutInflater mLayoutInflater;
 
@@ -525,6 +545,9 @@ public abstract class CardWithList extends Card {
                         object.getOnItemClickListener().onItemClick(mListView, viewChild, position, object);
                     }
                 });
+
+                view.setOnTouchListener(new SwipeDismissListItemViewTouchListener(viewChild, mListView, object));
+
             }
 
             return viewChild;
@@ -547,6 +570,10 @@ public abstract class CardWithList extends Card {
             //Object
             ListObject object = getItem(position);
             return object.getObjectId();
+        }
+
+        public void setExpanded(int position, boolean expanded){
+            getItem(position).setExpanded(expanded);
         }
     }
 

--- a/library/src/main/java/it/gmariotti/cardslib/library/prototypes/CardWithList.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/prototypes/CardWithList.java
@@ -509,7 +509,9 @@ public abstract class CardWithList extends Card {
      */
     public class LinearListAdapter extends ArrayAdapter<ListObject> {
 
-        LayoutInflater mLayoutInflater;
+        private ListObject lastExpanded;
+
+        private LayoutInflater mLayoutInflater;
 
         /**
          * Constructor
@@ -574,6 +576,27 @@ public abstract class CardWithList extends Card {
 
         public void setExpanded(int position, boolean expanded){
             getItem(position).setExpanded(expanded);
+        }
+
+        public void setLastExpanded(ListObject item){
+            lastExpanded = item;
+        }
+
+        public void collapseAll(){
+            int count = getCount();
+            for(int i = 0; i < count;i++){
+                if(getItem(i).isExpanded()){
+                    getItem(i).setExpanded(false);
+                    notifyDataSetChanged();
+                }
+            }
+        }
+
+        public void collapseLastExpanded(){
+           if(lastExpanded!=null){
+               lastExpanded.setExpanded(false);
+               notifyDataSetChanged();
+           }
         }
     }
 

--- a/library/src/main/java/it/gmariotti/cardslib/library/prototypes/LinearListView.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/prototypes/LinearListView.java
@@ -69,4 +69,8 @@ public class LinearListView extends LinearLayout {
         }
     }
 
+    public CardWithList.LinearListAdapter getAdapter(){
+        return mListAdapter;
+    }
+
 }

--- a/library/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissListItemViewTouchListener.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissListItemViewTouchListener.java
@@ -1,0 +1,176 @@
+
+/*
+ * ******************************************************************************
+ *   Copyright (c) 2013 Roman Nurik,2013-2014 Gabriele Mariotti.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *  *****************************************************************************
+ */
+
+package it.gmariotti.cardslib.library.view.listener;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.VelocityTracker;
+import android.view.View;
+
+import it.gmariotti.cardslib.library.prototypes.CardWithList;
+import it.gmariotti.cardslib.library.prototypes.LinearListView;
+
+
+public class SwipeDismissListItemViewTouchListener implements View.OnTouchListener {
+
+    private CardWithList.ListObject listObject;
+    private LinearListView listView;
+
+    // Cached ViewConfiguration and system-wide constant values
+    private int mSlop;
+    private int mMinFlingVelocity;
+    private int mMaxFlingVelocity;
+    private long mAnimationTime;
+
+    // Fixed properties
+    private View itemView;
+    //private DismissCallbacks mCallbacks;
+    private int mViewWidth = 1; // 1 and not 0 to prevent dividing by zero
+
+    // Transient properties
+    private float mDownX;
+    //private Card mToken;
+    private boolean mSwiping;
+    private VelocityTracker mVelocityTracker;
+    private boolean mPaused;
+    private float mTranslationX;
+
+
+   public SwipeDismissListItemViewTouchListener(View itemView, LinearListView mListView, CardWithList.ListObject listObject){
+       this.listObject = listObject;
+       this.listView = mListView;
+       this.itemView = itemView;
+   }
+
+    @Override
+    public boolean onTouch(View view, MotionEvent motionEvent) {
+
+        // offset because the view is translated during swipe
+        motionEvent.offsetLocation(mTranslationX, 0);
+
+        if (mViewWidth < 2) {
+            mViewWidth = itemView.getWidth();
+        }
+
+        switch (motionEvent.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN: {
+                if (mPaused) {
+                    return false;
+                }
+
+                // TODO: ensure this is a finger, and set a flag
+
+                mDownX = motionEvent.getRawX();
+                if (true) {
+                    mVelocityTracker = VelocityTracker.obtain();
+                    mVelocityTracker.addMovement(motionEvent);
+                }
+                view.onTouchEvent(motionEvent);
+                //return true;
+                return false;  //fixing swipe and click together
+            }
+
+            case MotionEvent.ACTION_UP: {
+                if (mVelocityTracker == null) {
+                    break;
+                }
+
+                float deltaX = motionEvent.getRawX() - mDownX;
+                mVelocityTracker.addMovement(motionEvent);
+                mVelocityTracker.computeCurrentVelocity(1000);
+                float velocityX = mVelocityTracker.getXVelocity();
+                float absVelocityX = Math.abs(velocityX);
+                float absVelocityY = Math.abs(mVelocityTracker.getYVelocity());
+                boolean dismiss = false;
+                boolean dismissRight = false;
+                if (Math.abs(deltaX) > mViewWidth / 2) {
+                    dismiss = true;
+                    dismissRight = deltaX > 0;
+                } else if (mMinFlingVelocity <= absVelocityX
+                        && absVelocityX <= mMaxFlingVelocity
+                        && absVelocityY < absVelocityX) {
+                    // dismiss only if flinging in the same direction as dragging
+                    dismiss = (velocityX < 0) == (deltaX < 0);
+                    dismissRight = mVelocityTracker.getXVelocity() > 0;
+                }
+                if (dismiss) {
+                    // dismiss
+
+                    itemView.animate()
+                            .translationX(dismissRight ? mViewWidth : -mViewWidth)
+                            .alpha(0).setDuration(mAnimationTime)
+                            .setListener(new AnimatorListenerAdapter() {
+                                @Override
+                                public void onAnimationEnd(Animator animation) {
+                                   // performDismiss()
+                                    Log.d("TAG","Desmis....");
+
+                                    //itemView.invalidate();
+                                    listView.getAdapter().remove(listObject);
+                                    ;
+                                }
+                            });
+                } else {
+                    // cancel
+                    itemView.animate().translationX(0).alpha(1)
+                            .setDuration(mAnimationTime).setListener(null);
+                }
+                mVelocityTracker.recycle();
+                mVelocityTracker = null;
+                mDownX = 0;
+                mSwiping = false;
+                break;
+            }
+
+            case MotionEvent.ACTION_MOVE: {
+                if (mVelocityTracker == null || mPaused) {
+                    break;
+                }
+
+                mVelocityTracker.addMovement(motionEvent);
+                float deltaX = motionEvent.getRawX() - mDownX;
+                if (Math.abs(deltaX) > mSlop) {
+                    mSwiping = true;
+                    itemView.getParent().requestDisallowInterceptTouchEvent(true);
+
+                    // Cancel ListView's touch (un-highlighting the item)
+                    MotionEvent cancelEvent = MotionEvent.obtain(motionEvent);
+                    cancelEvent
+                            .setAction(MotionEvent.ACTION_CANCEL
+                                    | (motionEvent.getActionIndex() << MotionEvent.ACTION_POINTER_INDEX_SHIFT));
+                    itemView.onTouchEvent(cancelEvent);
+                    cancelEvent.recycle();
+                }
+
+                if (mSwiping) {
+                    mTranslationX = deltaX;
+                    itemView.setTranslationX(deltaX);
+                   /* itemView.setAlpha(Math.max(0f,
+                            Math.min(1f, 1f - 2f * Math.abs(deltaX) / mViewWidth)));*/
+                    return true;
+                }
+                break;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
What do you think?

In a nutshell:
GoogleNowWeatherCard.java 
- in setupChild view get references to new buttons/textviews in hidden layout
- using listobject.isExpanded() determine if the view is drawn collapsed or opened (ie if refresh is forced due to new items or items being deleted, keep the correct items expanded)
- in onItemClick either expand or contract hidden layout. here we use an animation. after its done set the object's expanded property


CardWithList.java
- added expanded properties to listobject

- made LinearListAdapter public (swipe listener needs to be able to remove items from the adapter)

LinearListView.java
-swipe listener needs access to the adapter so made a getAdapter() method

SwipeDismissListItemViewTouchListener.java
-new class based off of SwipeDismissViewTouchListener.java
- we aren't working with cards now, so the other listeners don't really work...

I still have other things I want to add, (such as notification+undo when sub item is removed)
but this a working prototype.
