### PR TITLE
Allow user to establish state in CardWithList

### DIFF
--- a/library/src/main/java/it/gmariotti/cardslib/library/prototypes/CardWithList.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/prototypes/CardWithList.java
@@ -159,10 +159,6 @@ public abstract class CardWithList extends Card {
      * Init the card
      */
     public void init() {
-<<<<<<< HEAD
-=======
-        init();
->>>>>>> f1b01a76a5048c65207d8d41d8d106c5dc66e621
 
         //Init the CardHeader
         mCardHeader = initCardHeader();


### PR DESCRIPTION
As pointed out in issue #194, calling init() inside of the constructor does not allow the user to create state for their header or card.  

I've removed the call to init() in the constructor and changed the visibility of the init() method to public.
