### PR TITLE
Add ability to restrict card swipe direction.

### DIFF
--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardArrayAdapter.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardArrayAdapter.java
@@ -88,6 +88,12 @@ public class CardArrayAdapter extends BaseCardArrayAdapter implements UndoBarCon
     protected SwipeDismissListViewTouchListener mOnTouchListener;
 
     /**
+     * Swipe direction, to be used when mOnTouchListener is created
+     */
+    protected SwipeDismissListViewTouchListener.SwipeDirection mSwipeDirection =
+                                SwipeDismissListViewTouchListener.SwipeDirection.BOTH;
+
+    /**
      * Used to enable an undo message after a swipe action
      */
     protected boolean mEnableUndo=false;
@@ -193,6 +199,7 @@ public class CardArrayAdapter extends BaseCardArrayAdapter implements UndoBarCon
         if (card.isSwipeable()){
             if (mOnTouchListener == null){
                 mOnTouchListener = new SwipeDismissListViewTouchListener(mCardListView, mCallback);
+                mOnTouchListener.setSwipeDirection(mSwipeDirection);
                 // Setting this scroll listener is required to ensure that during
                 // ListView scrolling, we don't look for swipes.
                 if (mCardListView.getOnScrollListener() == null){
@@ -224,6 +231,18 @@ public class CardArrayAdapter extends BaseCardArrayAdapter implements UndoBarCon
 
         if (cardView == null) return;
         cardView.setOnExpandListAnimatorListener(mCardListView);
+    }
+
+    /**
+     * Sets this CardArrayAdapter so that only a single swipe direction will
+     * be enabled.
+     *
+     */
+    public void setSwipeDirection(SwipeDismissListViewTouchListener.SwipeDirection swipeDirection) {
+        if (mOnTouchListener != null) {
+            mOnTouchListener.setSwipeDirection(swipeDirection);
+        }
+        mSwipeDirection = swipeDirection;
     }
 
     // -------------------------------------------------------------

--- a/library/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissListViewTouchListener.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissListViewTouchListener.java
@@ -104,6 +104,7 @@ public class SwipeDismissListViewTouchListener implements View.OnTouchListener {
     private int mDownPosition;
     private View mDownView;
     private boolean mPaused;
+    private SwipeDirection mSwipeDirection = SwipeDirection.BOTH;
 
     private int swipeDistanceDivisor = 2;
 
@@ -126,6 +127,22 @@ public class SwipeDismissListViewTouchListener implements View.OnTouchListener {
          *                               order for convenience.
          */
         void onDismiss(ListView listView, int[] reverseSortedPositions);
+    }
+
+    public enum SwipeDirection {
+        BOTH(0),
+        LEFT(1),
+        RIGHT(2);
+
+        private final int mValue;
+
+        private SwipeDirection(int value) {
+            mValue = value;
+        }
+
+        public int getValue() {
+            return mValue;
+        }
     }
 
     /**
@@ -318,7 +335,10 @@ public class SwipeDismissListViewTouchListener implements View.OnTouchListener {
                 mVelocityTracker.addMovement(motionEvent);
                 float deltaX = motionEvent.getRawX() - mDownX;
                 float deltaY = motionEvent.getRawY() - mDownY;
-                if (Math.abs(deltaX) > mSlop && Math.abs(deltaY) < Math.abs(deltaX) / 2)  {
+                boolean movementAllowed = isSwipeMovementAllowed(deltaX);
+                if (movementAllowed
+                    && Math.abs(deltaX) > mSlop
+                    && Math.abs(deltaY) < Math.abs(deltaX) / 2)  {
                     mSwiping = true;
                     mSwipingSlop = (deltaX > 0 ? mSlop : -mSlop);
                     mListView.requestDisallowInterceptTouchEvent(true);
@@ -443,5 +463,22 @@ public class SwipeDismissListViewTouchListener implements View.OnTouchListener {
 
         mPendingDismisses.add(new PendingDismissData(dismissPosition, dismissView));
         animator.start();
+    }
+
+    private boolean isSwipeMovementAllowed(float deltaX) {
+        switch (mSwipeDirection) {
+            case BOTH:
+                return Math.abs(deltaX) > 0;
+            case RIGHT:
+                return deltaX > 0;
+            case LEFT:
+                return deltaX < 0;
+            default:
+                return false;
+        }
+    }
+
+    public void setSwipeDirection(SwipeDirection direction) {
+        mSwipeDirection = direction;
     }
 }


### PR DESCRIPTION
Added a field to specify a single direction for cards in a CardListView to be able to be swiped. Cards in a CardListView can be swiped left, right or both. The default, if not set, is both (the same behavior as it is currently). 

I needed this feature for a project I am working on. I'm not sure if you're interested in including it, but thought I'd propose it just in case.
