### PR TITLE
Track updates to underlying list in mInternalObjects on notifyDataSetChanged().

### DIFF
--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardArrayAdapter.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardArrayAdapter.java
@@ -294,6 +294,14 @@ public class CardArrayAdapter extends BaseCardArrayAdapter implements UndoBarCon
             }
             notifyDataSetChanged();
 
+            // Add back the cards that were removed into mInternalObjects,
+            // since notifyDataSetChanged rebuilt it.
+            if (isEnableUndo()) {
+                for (Card card : removedCards) {
+                    mInternalObjects.put(card.getId(), card);
+                }
+            }
+
             //Check for a undo message to confirm
             if (isEnableUndo() && mUndoBarController!=null){
 

--- a/library/src/main/java/it/gmariotti/cardslib/library/internal/CardArrayAdapter.java
+++ b/library/src/main/java/it/gmariotti/cardslib/library/internal/CardArrayAdapter.java
@@ -470,6 +470,18 @@ public class CardArrayAdapter extends BaseCardArrayAdapter implements UndoBarCon
         }
     }
 
+    @Override
+    public void notifyDataSetChanged() {
+        super.notifyDataSetChanged();
+        if (mEnableUndo) {
+            mInternalObjects = new HashMap<String, Card>();
+            for (int i = 0; i < getCount(); i++) {
+                Card card = getItem(i);
+                mInternalObjects.put(card.getId(), card);
+            }
+        }
+    }
+
     // -------------------------------------------------------------
     //  Getters and Setters
     // -------------------------------------------------------------


### PR DESCRIPTION
When working on my project, I realized that this important piece was missing to my previous pull request. If the list that the CardArrayAdapter is referencing is modified outside of the adapter and notifyDataSetChanged() is called, mInternalObjects will be in an incorrect state. This can completely break the undo functionality.

The solution is to totally regenerate mInternalObjects when notifyDataSetChanged is called, since we have no guarantee what state the ArrayList is in anymore. Using notifyDataSetChanged is a relatively common workflow, so this should be patched.
