### PR TITLE
Fix ForegroundLinearLayout

### DIFF
--- a/library-core/src/main/java/it/gmariotti/cardslib/library/view/ForegroundLinearLayout.java
+++ b/library-core/src/main/java/it/gmariotti/cardslib/library/view/ForegroundLinearLayout.java
@@ -26,12 +26,12 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.widget.LinearLayout;
 
 import it.gmariotti.cardslib.library.R;
-
 
 public class ForegroundLinearLayout extends LinearLayout {
 
@@ -183,7 +183,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        mForegroundBoundsChanged = changed;
+        mForegroundBoundsChanged = true;
     }
 
     @Override
@@ -193,7 +193,7 @@ public class ForegroundLinearLayout extends LinearLayout {
     }
 
     @Override
-    public void draw(Canvas canvas) {
+    public void draw(@NonNull Canvas canvas) {
         super.draw(canvas);
 
         if (mForeground != null) {
@@ -222,7 +222,6 @@ public class ForegroundLinearLayout extends LinearLayout {
             foreground.draw(canvas);
         }
     }
-
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override


### PR DESCRIPTION
When used in a RecyclerView or AbsListView, about 50% the first screen
of items will not have the foreground set because the foreground will
be drawn in an empty Rect.
See http://stackoverflow.com/a/28015226/1696171
