### PR TITLE
Fix margin/gap inconsistency between 5.0 and pre-5.0

### DIFF
--- a/library-core/src/main/res/layout/native_list_card_layout.xml
+++ b/library-core/src/main/res/layout/native_list_card_layout.xml
@@ -27,10 +27,12 @@
     <it.gmariotti.cardslib.library.view.CardViewNative
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:card="http://schemas.android.com/apk/res-auto"
+        xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:id="@+id/list_cardId"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/native_list_card.base"
+        card_view:cardUseCompatPadding="true"
         card:card_layout_resourceID="@layout/native_card_layout"/>
 
 </LinearLayout>

--- a/library-core/src/main/res/layout/native_list_card_thumbnail_layout.xml
+++ b/library-core/src/main/res/layout/native_list_card_thumbnail_layout.xml
@@ -27,10 +27,12 @@
 <it.gmariotti.cardslib.library.view.CardViewNative
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card="http://schemas.android.com/apk/res-auto"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:id="@+id/list_cardId"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     style="@style/native_list_card.thumbnail"
+    card_view:cardUseCompatPadding="true"
     card:card_layout_resourceID="@layout/native_card_thumbnail_layout"
     />
 

--- a/library-core/src/main/res/values/dimens.xml
+++ b/library-core/src/main/res/values/dimens.xml
@@ -141,14 +141,14 @@
     <!-- List -->
     <dimen name="native_list_card_margin_left">0dp</dimen>
     <dimen name="native_list_card_margin_right">0dp</dimen>
-    <dimen name="native_list_card_margin_bottom">6dp</dimen>
-    <dimen name="native_list_card_margin_top">6dp</dimen>
+    <dimen name="native_list_card_margin_bottom">0dp</dimen>
+    <dimen name="native_list_card_margin_top">0dp</dimen>
 
     <!-- RecyclerView -->
     <dimen name="native_recyclerview_card_margin_left">0dp</dimen>
     <dimen name="native_recyclerview_card_margin_right">0dp</dimen>
-    <dimen name="native_recyclerview_card_margin_bottom">6dp</dimen>
-    <dimen name="native_recyclerview_card_margin_top">6dp</dimen>
+    <dimen name="native_recyclerview_card_margin_bottom">0dp</dimen>
+    <dimen name="native_recyclerview_card_margin_top">0dp</dimen>
 
     <!-- Grid -->
     <dimen name="grid_card_padding_left">2dp</dimen>

--- a/library-recyclerview/src/main/res/layout/native_recyclerview_card_layout.xml
+++ b/library-recyclerview/src/main/res/layout/native_recyclerview_card_layout.xml
@@ -25,10 +25,12 @@
     <it.gmariotti.cardslib.library.view.CardViewNative
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:card="http://schemas.android.com/apk/res-auto"
+        xmlns:card_view="http://schemas.android.com/apk/res-auto"
         android:id="@+id/list_cardId"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/native_recyclerview_card.base"
+        card_view:cardUseCompatPadding="true"
         card:card_layout_resourceID="@layout/native_card_layout"/>
 
 

--- a/library-recyclerview/src/main/res/layout/native_recyclerview_card_thumbnail_layout.xml
+++ b/library-recyclerview/src/main/res/layout/native_recyclerview_card_thumbnail_layout.xml
@@ -23,9 +23,11 @@
 <it.gmariotti.cardslib.library.view.CardViewNative
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card="http://schemas.android.com/apk/res-auto"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:id="@+id/list_cardId"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     style="@style/native_recyclerview_card.thumbnail"
+    card_view:cardUseCompatPadding="true"
     card:card_layout_resourceID="@layout/native_card_thumbnail_layout"
     />


### PR DESCRIPTION
On pre-5.0, `CardView` (appcompat v7) adds a margin to draw the shadow. cardslib also adds a `6dp` margin to the cards in `ListView`s and `RecyclerView`s, which results in large gaps between cards on pre-5.0 (see screenshots).

`CardView` has a [`card_view:cardUseCompatPadding` attribute](https://developer.android.com/reference/android/support/v7/widget/CardView.html#attr_android.support.v7.cardview:cardUseCompatPadding), which makes the 5.0 and pre-5.0 behavior match if set to true.

With this commit, `ListView` and `RecyclerView` now behave identically on <=4.4 and 5.0. (Also fixes shadows on the sides of cards on 5.0).

| Platform | Before | After |
| --- | --- | --- |
| 4.4 ListView | [![](http://i.imgur.com/concCU1t.png)](http://i.imgur.com/concCU1.png) | [![](http://i.imgur.com/oYwOXt6t.png)](http://i.imgur.com/oYwOXt6.png) |
| 4.4 RecyclerView | [![](http://i.imgur.com/nne61Ymt.png)](http://i.imgur.com/nne61Ym.png) | [![](http://i.imgur.com/M5emjMwt.png)](http://i.imgur.com/M5emjMw.png) |
| 5.0 ListView | [![](http://i.imgur.com/SaI4rbyt.png)](http://i.imgur.com/SaI4rby.png) | [![](http://i.imgur.com/zaHeqOKt.png)](http://i.imgur.com/zaHeqOK.png) |
| 5.0 RecyclerView | [![](http://i.imgur.com/pmBKY3Nt.png)](http://i.imgur.com/pmBKY3N.png) | [![](http://i.imgur.com/qAJduAgt.png)](http://i.imgur.com/qAJduAg.png) |
