### PR TITLE
Fix stutter when card is moved in opposite direction

### DIFF
--- a/library-core/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissViewTouchListener.java
+++ b/library-core/src/main/java/it/gmariotti/cardslib/library/view/listener/SwipeDismissViewTouchListener.java
@@ -224,7 +224,8 @@ public class SwipeDismissViewTouchListener implements View.OnTouchListener {
                 mVelocityTracker.addMovement(motionEvent);
                 float deltaX = motionEvent.getRawX() - mDownX;
                 float deltaY = motionEvent.getRawY() - mDownY;
-                if (Math.abs(deltaX) > mSlop && Math.abs(deltaY) < Math.abs(deltaX) / 2) {
+                if (Math.abs(deltaX) > mSlop && Math.abs(deltaY) < Math.abs(deltaX) / 2
+                        && !mSwiping) {
                     mSwiping = true;
                     ((View)mCardView).getParent().requestDisallowInterceptTouchEvent(true);
                     mSwipingSlop = (deltaX > 0 ? mSlop : -mSlop);


### PR DESCRIPTION
- Bug: start moving > change direction: when abs(delta) > slop, the
  touch is cancelled
