### PR TITLE
Fix to issue #361

### DIFF
--- a/library-cards/src/main/java/it/gmariotti/cardslib/library/cards/base/BaseMaterialCard.java
+++ b/library-cards/src/main/java/it/gmariotti/cardslib/library/cards/base/BaseMaterialCard.java
@@ -79,6 +79,9 @@ public abstract class BaseMaterialCard extends Card {
                 stub.setLayoutResource(getLayout_supplemental_actions_id());
                 return stub.inflate();
             }
+            else {
+                return ((View) getCardView()).findViewById(R.id.card_supplemental_actions);
+            }
         }
         return null;
     }


### PR DESCRIPTION
Return R.id.card_supplemental_actions view when layout is already inflated and viewstub replaced.
