### PR TITLE
Replaced compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,22 @@ Card Library is pushed to Maven Central as an AAR, so you just need to add the f
 
     dependencies {
         //Core
-        compile 'com.github.gabrielemariotti.cards:cardslib-core:2.1.0'
+        implementation 'com.github.gabrielemariotti.cards:cardslib-core:2.1.0'
         
         //Optional for built-in cards
-        compile 'com.github.gabrielemariotti.cards:cardslib-cards:2.1.0'
+        implementation 'com.github.gabrielemariotti.cards:cardslib-cards:2.1.0'
                 
         //Optional for RecyclerView
-        compile 'com.github.gabrielemariotti.cards:cardslib-recyclerview:2.1.0'
+        implementation 'com.github.gabrielemariotti.cards:cardslib-recyclerview:2.1.0'
           
         //Optional for staggered grid view
-        compile 'com.github.gabrielemariotti.cards:cardslib-extra-staggeredgrid:2.1.0'
+        implementation 'com.github.gabrielemariotti.cards:cardslib-extra-staggeredgrid:2.1.0'
          
         //Optional for drag and drop
-        compile 'com.github.gabrielemariotti.cards:cardslib-extra-dragdrop:2.1.0'
+        implementation 'com.github.gabrielemariotti.cards:cardslib-extra-dragdrop:2.1.0'
         
         //Optional for twoway  (coming soon)
-        //compile 'com.github.gabrielemariotti.cards:cardslib-extra-twoway:2.1.0'
+        //implementation 'com.github.gabrielemariotti.cards:cardslib-extra-twoway:2.1.0'
         
     }
 
@@ -69,10 +69,10 @@ If you would like to use the last **v1 stable version** you can use:
     
     dependencies {
         //Core card library
-        compile 'com.github.gabrielemariotti.cards:library:1.9.1'
+        implementation 'com.github.gabrielemariotti.cards:library:1.9.1'
 
         //Extra card library, it is required only if you want to use integrations with other libraries
-        compile 'com.github.gabrielemariotti.cards:library-extra:1.9.1'
+        implementation 'com.github.gabrielemariotti.cards:library-extra:1.9.1'
     }
 
 


### PR DESCRIPTION
Because of Google making compile deprecated end 2018, it should be replaced with implementation according to Android Studio warnings.